### PR TITLE
Small improvements to builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,58 @@
+name: Build image
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ inputs.image_name}}
+          tags: |
+            type=sha,prefix=
+        env:
+          DOCKER_METADATA_SHORT_SHA_LENGTH: 8
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: packages/${{ inputs.image_name}}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ inputs.image_name}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-publish-mock.yml
+++ b/.github/workflows/docker-publish-mock.yml
@@ -7,53 +7,8 @@ on:
     branches:
       - main
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}-mock
-
 jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=sha,prefix=
-        env:
-          DOCKER_METADATA_SHORT_SHA_LENGTH: 8
-
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
-        with:
-          context: packages/mosip-mock
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+  build-and-push:
+    uses: ./.github/workflows/build.yml
+    with:
+      image_name: ${{ github.repository }}-mock

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,53 +7,8 @@ on:
     branches:
       - main
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=sha,prefix=
-        env:
-          DOCKER_METADATA_SHORT_SHA_LENGTH: 8
-
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
-        with:
-          context: packages/server
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+  build-and-push:
+    uses: ./.github/workflows/build.yml
+    with:
+      image_name: ${{ github.repository }}-mock

--- a/packages/mosip-mock/Dockerfile
+++ b/packages/mosip-mock/Dockerfile
@@ -3,9 +3,8 @@ WORKDIR /usr/src/app
 
 COPY package.json package.json
 COPY yarn.lock yarn.lock
-COPY src/ src/
 RUN yarn install --production --frozen-lockfile
 
-EXPOSE 2024
+COPY src/ src/
 
 CMD ["yarn", "start"]

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -3,9 +3,8 @@ WORKDIR /usr/src/app
 
 COPY package.json package.json
 COPY yarn.lock yarn.lock
-COPY src/ src/
 RUN yarn install --production --frozen-lockfile
 
-EXPOSE 2024
+COPY src/ src/
 
 CMD ["yarn", "start"]


### PR DESCRIPTION
Small improvements to builds here

- Extract `build` as generic workflow vs copypasting
- Use versions on actions (vs SHAs) to auto pick-up non-breaking improvements
- Edit `Dockerfile` s to copy `src` (eg the files we most often change) only after `yarn install` has ran to minimise cache busts

Test run at https://github.com/opencrvs/mosip/actions/runs/11975493557

