### PR TITLE
chore: use national id instead of configurable identifier

### DIFF
--- a/packages/server/src/webhooks/mosip.ts
+++ b/packages/server/src/webhooks/mosip.ts
@@ -34,7 +34,7 @@ export const mosipHandler = async (
     {
       id: eventId,
       registrationNumber,
-      identifiers: [{ type: "BIRTH_CONFIGURABLE_IDENTIFIER_1", value: nid }],
+      identifiers: [{ type: "NATIONAL_ID", value: nid }],
     },
     { headers: { Authorization: `Bearer ${token}` } }
   );


### PR DESCRIPTION
This allows searching with the NID