### PR TITLE
chore: E-Signet mock authorizer redirect fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip",
-  "version": "1.7.0-alpha.17",
+  "version": "1.7.0-alpha.18",
   "license": "MPL-2.0",
   "private": true,
   "packageManager": "yarn@1.22.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip",
-  "version": "1.7.0-alpha.16",
+  "version": "1.7.0-alpha.17",
   "license": "MPL-2.0",
   "private": true,
   "packageManager": "yarn@1.22.13",

--- a/packages/country-config/package.json
+++ b/packages/country-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip",
-  "version": "1.7.0-alpha.16",
+  "version": "1.7.0-alpha.17",
   "license": "MPL-2.0",
   "main": "./build/index.js",
   "exports": {

--- a/packages/country-config/package.json
+++ b/packages/country-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip",
-  "version": "1.7.0-alpha.17",
+  "version": "1.7.0-alpha.18",
   "license": "MPL-2.0",
   "main": "./build/index.js",
   "exports": {

--- a/packages/esignet-mock/package.json
+++ b/packages/esignet-mock/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencrvs/esignet-mock",
   "license": "MPL-2.0",
-  "version": "1.7.0-alpha.16",
+  "version": "1.7.0-alpha.17",
   "main": "index.js",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch src/index.ts",

--- a/packages/esignet-mock/package.json
+++ b/packages/esignet-mock/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencrvs/esignet-mock",
   "license": "MPL-2.0",
-  "version": "1.7.0-alpha.17",
+  "version": "1.7.0-alpha.18",
   "main": "index.js",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch src/index.ts",

--- a/packages/esignet-mock/src/constants.ts
+++ b/packages/esignet-mock/src/constants.ts
@@ -2,6 +2,5 @@ import { cleanEnv, port, str, url } from "envalid";
 
 export const env = cleanEnv(process.env, {
   PORT: port({ default: 20260 }),
-  HOST: str({ default: "0.0.0.0", devDefault: "localhost" }),
-  CLIENT_URL: url({ devDefault: "http://localhost:3000" }),
+  HOST: str({ default: "0.0.0.0", devDefault: "localhost" })
 });

--- a/packages/esignet-mock/src/index.ts
+++ b/packages/esignet-mock/src/index.ts
@@ -131,13 +131,15 @@ app.post("/oidc/userinfo", {
 const authorizeSchema = {
   querystring: {
     type: "object",
-    required: ["client_id", "response_type", "scope", "acr_values", "claims"],
+    required: ["client_id", "response_type", "scope", "acr_values", "claims", "state", "redirect_uri"],
     properties: {
       client_id: { type: "string" },
       response_type: { type: "string" },
       scope: { type: "string" },
       acr_values: { type: "string" },
       claims: { type: "string" },
+      state: { type: "string" },
+      redirect_uri: { type: "string" },
     },
   },
 };
@@ -149,13 +151,13 @@ app.get("/authorize", {
     const html = readFileSync(htmlFilePath, "utf-8");
 
     const modifiedHtml = html
-      .replace(/{{CLIENT_URL}}/g, env.CLIENT_URL)
       .replace(/{{client_id}}/g, request.query.client_id)
       .replace(/{{response_type}}/g, request.query.response_type)
       .replace(/{{scope}}/g, request.query.scope)
       .replace(/{{acr_values}}/g, request.query.acr_values)
       .replace(/{{claims}}/g, request.query.claims)
-      .replace(/{{state}}/g, request.query.state);
+      .replace(/{{state}}/g, request.query.state)
+      .replace(/{{redirect_uri}}/g, request.query.redirect_uri);
 
     return reply.type("text/html").send(modifiedHtml);
   },

--- a/packages/esignet-mock/src/mock-authorizer/index.html
+++ b/packages/esignet-mock/src/mock-authorizer/index.html
@@ -6,7 +6,6 @@
     <title>Mock authorizer</title>
   </head>
   <body>
-    <p>CLIENT_URL: {{CLIENT_URL}}</p>
     <p>client_id: {{client_id}}</p>
     <p>response_type: {{response_type}}</p>
     <p>scope: {{scope}}</p>
@@ -21,7 +20,8 @@
       const params = new URLSearchParams(window.location.search);
       const destinationURL = new URL(params.get("redirect_uri"));
       destinationURL.searchParams.set("code", "esignet-mock-code");
-      window.location.replace(destinationURL);
+      destinationURL.searchParams.set("state", params.get("state"));
+      window.location.replace(destinationURL.href);
     }
   </script>
 </html>

--- a/packages/mosip-api/package.json
+++ b/packages/mosip-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip-api",
-  "version": "1.7.0-alpha.16",
+  "version": "1.7.0-alpha.17",
   "license": "MPL-2.0",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch src/index.ts",

--- a/packages/mosip-api/package.json
+++ b/packages/mosip-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip-api",
-  "version": "1.7.0-alpha.17",
+  "version": "1.7.0-alpha.18",
   "license": "MPL-2.0",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch src/index.ts",

--- a/packages/mosip-mock/package.json
+++ b/packages/mosip-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip-mock",
-  "version": "1.7.0-alpha.17",
+  "version": "1.7.0-alpha.18",
   "license": "MPL-2.0",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch src/index.ts",

--- a/packages/mosip-mock/package.json
+++ b/packages/mosip-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip-mock",
-  "version": "1.7.0-alpha.16",
+  "version": "1.7.0-alpha.17",
   "license": "MPL-2.0",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch src/index.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1912,6 +1912,7 @@ statuses@2.0.1:
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1937,6 +1938,7 @@ string_decoder@^1.3.0:
     safe-buffer "~5.2.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
@tahmidrahman-dsi this PR fixes an issue in the mock-authorizer HTML so you can see it redirecting back to OpenCRVS.  The URL looks like this:

```
http://localhost:3000/drafts/11bd8063-2503-4092-a535-7bd0e4643b17/events/birth/informant/group/informant-view-group?code=esignet-mock-code&state=fetch-on-mount
```

But when OpenCRVS renders, something isnt right because the app directs to: http://localhost:3000/registration-home/my-drafts/1. Does something need to change now that this new drafts queue is available?