### PR TITLE
fix: Copy yarn.lock to docker build context (#55)

### DIFF
--- a/.github/workflows/docker-publish-esignet-mock.yml
+++ b/.github/workflows/docker-publish-esignet-mock.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 env:
   REGISTRY: ghcr.io
@@ -40,6 +43,9 @@ jobs:
             type=sha,prefix=
         env:
           DOCKER_METADATA_SHORT_SHA_LENGTH: 7
+
+      - name: Copy yarn.lock to docker build context
+        run: cp yarn.lock packages/esignet-mock/yarn.lock
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/docker-publish-mosip-mock.yml
+++ b/.github/workflows/docker-publish-mosip-mock.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 env:
   REGISTRY: ghcr.io
@@ -40,6 +43,9 @@ jobs:
             type=sha,prefix=
         env:
           DOCKER_METADATA_SHORT_SHA_LENGTH: 7
+
+      - name: Copy yarn.lock to docker build context
+        run: cp yarn.lock packages/mosip-mock/yarn.lock
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 env:
   REGISTRY: ghcr.io
@@ -40,6 +43,9 @@ jobs:
             type=sha,prefix=
         env:
           DOCKER_METADATA_SHORT_SHA_LENGTH: 7
+
+      - name: Copy yarn.lock to docker build context
+        run: cp yarn.lock packages/mosip-api/yarn.lock
 
       - name: Build and push Docker image
         id: push

--- a/packages/esignet-mock/Dockerfile
+++ b/packages/esignet-mock/Dockerfile
@@ -2,6 +2,7 @@ FROM node:23.1.0
 WORKDIR /usr/src/app
 
 COPY package.json package.json
+COPY yarn.lock yarn.lock
 RUN yarn install --production --frozen-lockfile
 COPY src/ src/
 

--- a/packages/mosip-api/Dockerfile
+++ b/packages/mosip-api/Dockerfile
@@ -2,6 +2,7 @@ FROM node:23.1.0
 WORKDIR /usr/src/app
 
 COPY package.json package.json
+COPY yarn.lock yarn.lock
 COPY tsconfig.json tsconfig.json
 RUN yarn install --production --frozen-lockfile
 COPY src/ src/

--- a/packages/mosip-mock/Dockerfile
+++ b/packages/mosip-mock/Dockerfile
@@ -2,6 +2,7 @@ FROM node:23.1.0
 WORKDIR /usr/src/app
 
 COPY package.json package.json
+COPY yarn.lock yarn.lock
 RUN yarn install --production --frozen-lockfile
 COPY src/ src/
 


### PR DESCRIPTION
This PR implements fix for https://github.com/opencrvs/mosip/issues/55

Goal is to give access to root yarn.lock file from docker build context, which is limited to `packages/*` subfolders