### PR TITLE
fix: informant nid can be not found

### DIFF
--- a/packages/country-config/src/forms.ts
+++ b/packages/country-config/src/forms.ts
@@ -1,5 +1,3 @@
-// @TODO: Yet to be implemented! Placeholders for NPM publish.
-
 /**
  * E-Signet popup button and hidden field form definitions
  * @example

--- a/packages/mosip-api/src/routes/event-review.ts
+++ b/packages/mosip-api/src/routes/event-review.ts
@@ -108,7 +108,7 @@ export const reviewEventHandler = async (
     let informantNationalID;
 
     try {
-      getInformantNationalId(request.body);
+      informantNationalID = getInformantNationalId(request.body);
     } catch (e) {
       logger.info(
         { eventId },


### PR DESCRIPTION
When informants NID wasn't inputted, the route crashed. Fix includes try-catching the nid selection similarly to mothers and fathers nids.