### PR TITLE
fix: handle null userinfo

### DIFF
--- a/packages/mosip-api/src/esignet-api.ts
+++ b/packages/mosip-api/src/esignet-api.ts
@@ -219,5 +219,11 @@ export const fetchUserInfo = async (accessToken: string) => {
 
   const response = await request.text();
   const decodedResponse = decodeUserInfoResponse(response);
+  if (!decodedResponse) {
+    throw new Error(
+      "Something went wrong with the OIDP user info request. No user info was returned. Response from OIDP: " +
+        JSON.stringify(response),
+    );
+  }
   return pickUserInfo(decodedResponse);
 };


### PR DESCRIPTION
Fixes https://github.com/opencrvs/opencrvs-core/issues/9299

The issue used to occur when a wrong id (not included in mock-identities) is provided in esignet verification. 

### Before this change, mosip-api service logs were

```
[14:44:49.415] INFO: incoming request
    reqId: "req-3"
    req: {
      "method": "POST",
      "url": "/esignet/get-oidp-user-info?code=MDAwMDAwMA%3D%3D&state=fetch-on-mount",
      "host": "localhost:2024",
      "remoteAddress": "127.0.0.1",
      "remotePort": 57538
    }
[14:44:49.446] ERROR: Cannot read properties of null (reading 'given_name')
    reqId: "req-3"
    err: {
      "type": "TypeError",
      "message": "Cannot read properties of null (reading 'given_name')",
      "stack":
          TypeError: Cannot read properties of null (reading 'given_name')
              at pickUserInfo (/home/tahmid/Projects/OpenCRVS/mosip/packages/mosip-api/src/esignet-api.ts:191:25)
              at fetchUserInfo (/home/tahmid/Projects/OpenCRVS/mosip/packages/mosip-api/src/esignet-api.ts:222:10)
              at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    }
[14:44:49.450] INFO: request completed
    reqId: "req-3"
    res: {
      "statusCode": 500
    }
    responseTime: 34.538345992565155
 ```
 
###  After this change, mosip api service logs are like below
 
 ```
 [14:50:37.158] INFO: incoming request
    reqId: "req-3"
    req: {
      "method": "POST",
      "url": "/esignet/get-oidp-user-info?code=MDAwMDAwMA%3D%3D&state=fetch-on-mount",
      "host": "localhost:2024",
      "remoteAddress": "127.0.0.1",
      "remotePort": 43464
    }
[14:50:37.184] ERROR: Something went wrong with the OIDP user info request. No user info was returned. Response from OIDP: "{\"statusCode\":500,\"error\":\"Internal Server Error\",\"message\":\"Identity \\\"0000000\\\" not found! Uh oh...\"}"
    reqId: "req-3"
    err: {
      "type": "Error",
      "message": "Something went wrong with the OIDP user info request. No user info was returned. Response from OIDP: \"{\\\"statusCode\\\":500,\\\"error\\\":\\\"Internal Server Error\\\",\\\"message\\\":\\\"Identity \\\\\\\"0000000\\\\\\\" not found! Uh oh...\\\"}\"",
      "stack":
          Error: Something went wrong with the OIDP user info request. No user info was returned. Response from OIDP: "{\"statusCode\":500,\"error\":\"Internal Server Error\",\"message\":\"Identity \\\"0000000\\\" not found! Uh oh...\"}"
              at fetchUserInfo (/home/tahmid/Projects/OpenCRVS/mosip/packages/mosip-api/src/esignet-api.ts:223:11)
              at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    }
[14:50:37.186] INFO: request completed
    reqId: "req-3"
    res: {
      "statusCode": 500
    }
    responseTime: 28.303297996520996
 ```