### PR TITLE
feat: align service logging with redaction and structured events

### DIFF
--- a/packages/esignet-mock/src/index.ts
+++ b/packages/esignet-mock/src/index.ts
@@ -232,7 +232,9 @@ async function run() {
     host: env.HOST,
   });
 
-  console.log(`E-Signet mock server running at http://${env.HOST}:${env.PORT}`);
+  app.log.info(
+    `E-Signet mock server running at http://${env.HOST}:${env.PORT}`,
+  );
 }
 
 void run();

--- a/packages/mosip-api/src/esignet-api.ts
+++ b/packages/mosip-api/src/esignet-api.ts
@@ -17,6 +17,7 @@ import { isValid, format, Locale, parse } from "date-fns";
 import { enGB } from "date-fns/locale/en-GB";
 import { fr } from "date-fns/locale/fr";
 import fs from "node:fs";
+import type { FastifyBaseLogger } from "fastify";
 
 const OIDP_CLIENT_PRIVATE_KEY = fs
   .readFileSync(env.OIDP_CLIENT_PRIVATE_KEY_PATH)
@@ -74,6 +75,7 @@ type FetchTokenProps = {
   clientId: string;
   redirectUri: string;
   grantType?: string;
+  logger: FastifyBaseLogger;
 };
 
 const generateSignedJwt = async (clientId: string) => {
@@ -88,8 +90,6 @@ const generateSignedJwt = async (clientId: string) => {
     // aud: env.OPENID_PROVIDER_CLAIMS,
     aud: env.ESIGNET_TOKEN_URL,
   };
-
-  console.log("JWT payload", payload);
 
   const decodeKey = Buffer.from(OIDP_CLIENT_PRIVATE_KEY, "base64")?.toString();
   const jwkObject = JSON.parse(decodeKey);
@@ -106,21 +106,29 @@ export const fetchToken = async ({
   code,
   clientId,
   redirectUri,
+  logger,
 }: FetchTokenProps) => {
   const clientAssertion = await generateSignedJwt(clientId);
-  console.log("client assertion: ", clientAssertion);
+
+  const redirectUriWithoutQuery = redirectUri?.split("?")[0] ?? redirectUri;
   const body = new URLSearchParams({
     code: code,
     client_id: clientId,
-    redirect_uri: redirectUri?.split("?")[0] ?? redirectUri,
+    redirect_uri: redirectUriWithoutQuery,
     grant_type: "authorization_code",
     client_assertion_type:
       "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
     client_assertion: clientAssertion,
   });
 
-  console.log("fetch token request body", body.toString());
-  console.log("fetch token request url", env.ESIGNET_TOKEN_URL);
+  logger.debug(
+    {
+      event: "esignet.token.request",
+      tokenUrl: env.ESIGNET_TOKEN_URL,
+      redirectUri: redirectUriWithoutQuery,
+    },
+    "Requesting E-Signet token",
+  );
 
   const request = await fetch(env.ESIGNET_TOKEN_URL!, {
     method: "POST",
@@ -130,8 +138,18 @@ export const fetchToken = async ({
     body,
   });
 
+  if (!request.ok) {
+    logger.warn(
+      {
+        event: "esignet.token.request.failed",
+        statusCode: request.status,
+      },
+      "E-Signet token request failed",
+    );
+    throw new Error(`OIDP token request failed with status ${request.status}`);
+  }
+
   const response = await request.json();
-  console.log("fetch token response", response);
   return response as { access_token?: string };
 };
 
@@ -194,7 +212,10 @@ const decodeUserInfoResponse = (response: string) => {
   return jwt.decode(response) as OIDPUserInfo;
 };
 
-export const fetchUserInfo = async (accessToken: string) => {
+export const fetchUserInfo = async (
+  accessToken: string,
+  logger: FastifyBaseLogger,
+) => {
   const request = await fetch(env.ESIGNET_USERINFO_URL, {
     method: "GET",
     headers: {
@@ -202,13 +223,25 @@ export const fetchUserInfo = async (accessToken: string) => {
     },
   });
 
+  if (!request.ok) {
+    logger.warn(
+      {
+        event: "esignet.userinfo.request.failed",
+        statusCode: request.status,
+      },
+      "E-Signet user info request failed",
+    );
+    throw new Error(
+      `OIDP user info request failed with status ${request.status}`,
+    );
+  }
+
   const response = await request.text();
   const decodedResponse = decodeUserInfoResponse(response);
-  console.log("Decoded response", JSON.stringify(decodedResponse));
+
   if (!decodedResponse) {
     throw new Error(
-      "Something went wrong with the OIDP user info request. No user info was returned. Response from OIDP: " +
-        JSON.stringify(response),
+      "Something went wrong with the OIDP user info request. No user info was returned.",
     );
   }
   return pickUserInfo(decodedResponse);

--- a/packages/mosip-api/src/index.ts
+++ b/packages/mosip-api/src/index.ts
@@ -25,8 +25,30 @@ import {
 } from "./routes/debug-sqlite";
 import { verifyHandler, VerifySchema } from "./routes/verify";
 
+const loggerRedactPaths = [
+  "req.headers.authorization",
+  "req.headers.cookie",
+  "authorization",
+  "cookie",
+  "token",
+  "access_token",
+  "refresh_token",
+  "client_assertion",
+  "body.client_assertion",
+  "body.code",
+  "body.credential",
+  "body.event.data.credential",
+  "headers.authorization",
+  "headers.cookie",
+];
+
 const envToLogger = {
   development: {
+    level: process.env.LOG_LEVEL ?? "debug",
+    redact: {
+      paths: loggerRedactPaths,
+      censor: "[REDACTED]",
+    },
     transport: {
       target: "pino-pretty",
       options: {
@@ -34,7 +56,13 @@ const envToLogger = {
       },
     },
   },
-  production: true,
+  production: {
+    level: process.env.LOG_LEVEL ?? "info",
+    redact: {
+      paths: loggerRedactPaths,
+      censor: "[REDACTED]",
+    },
+  },
 };
 
 const initRoutes = (app: FastifyInstance) => {
@@ -106,9 +134,11 @@ const initRoutes = (app: FastifyInstance) => {
 
 let corePublicKey: string;
 let publicKeyUpdatedAt = Date.now();
+let publicKeyLogger: FastifyInstance["log"];
+
 const getCorePublicKey = async () => {
   if (!corePublicKey) {
-    corePublicKey = await getPublicKey();
+    corePublicKey = await getPublicKey(publicKeyLogger);
   }
 
   return corePublicKey;
@@ -122,6 +152,7 @@ export const buildFastify = async () => {
 
   app.setValidatorCompiler(validatorCompiler);
   app.setSerializerCompiler(serializerCompiler);
+  publicKeyLogger = app.log;
   app.register(formbody);
   app.register(cors, {
     origin: [env.CLIENT_APP_URL],
@@ -159,17 +190,26 @@ export const buildFastify = async () => {
         error.code === "FST_JWT_AUTHORIZATION_TOKEN_INVALID" &&
         moreThanAMinuteSinceLastUpdate
       ) {
-        app.log.info("🔁 JWT failed, refreshing public key...");
+        app.log.info(
+          { event: "jwt.verify.failed.refreshing-public-key" },
+          "JWT verification failed, refreshing public key",
+        );
         try {
-          corePublicKey = await getPublicKey();
+          corePublicKey = await getPublicKey(app.log);
           publicKeyUpdatedAt = Date.now();
           await request.jwtVerify();
           return;
         } catch (retryErr) {
-          app.log.error("🔐 JWT retry failed:", retryErr);
+          app.log.error(
+            { event: "jwt.verify.retry.failed", err: retryErr },
+            "JWT verification failed after public key refresh",
+          );
         }
       } else {
-        app.log.error("🔐 JWT verify failed:", err);
+        app.log.error(
+          { event: "jwt.verify.failed", err },
+          "JWT verification failed",
+        );
       }
 
       return reply.code(401).send({ error: "Unauthorized" });
@@ -188,22 +228,22 @@ async function run() {
     env.SQLITE_DATABASE_PATH,
   );
 
-  wasCreated && app.log.info("SQLite token storage created 🚀✅ ");
-  wasConnected && app.log.info("SQLite token storage connected ✅");
+  wasCreated && app.log.info("SQLite token storage created");
+  wasConnected && app.log.info("SQLite token storage connected");
 
   await app.ready();
   await app.listen({
     port: env.PORT,
     host: env.HOST,
     listenTextResolver: () =>
-      `OpenCRVS-MOSIP interoperability API running at http://${env.HOST}:${env.PORT} ✅`,
+      `OpenCRVS-MOSIP interoperability API running at http://${env.HOST}:${env.PORT}`,
   });
   app.log.info(
-    `Swagger UI running at http://${env.HOST}:${env.PORT}/documentation ✅`,
+    `Swagger UI running at http://${env.HOST}:${env.PORT}/documentation`,
   );
 
   const { topic } = await initWebSub();
-  app.log.info(`WebSub subscription initialized for topic '${topic}' ✅`);
+  app.log.info(`WebSub subscription initialized for topic '${topic}'`);
 
   process.on("exit", () => {
     database.close();

--- a/packages/mosip-api/src/opencrvs-api.ts
+++ b/packages/mosip-api/src/opencrvs-api.ts
@@ -1,6 +1,7 @@
 import { env } from "./constants";
 import { createClient } from "@opencrvs/toolkit/api";
 import crypto from "node:crypto";
+import type { FastifyBaseLogger } from "fastify";
 
 export class OpenCRVSError extends Error {
   constructor(message: string) {
@@ -10,19 +11,28 @@ export class OpenCRVSError extends Error {
 }
 
 /** Fetches the public key from OpenCRVS to be able to verify JWTs */
-export const getPublicKey = async (): Promise<string> => {
+export const getPublicKey = async (
+  logger: FastifyBaseLogger,
+): Promise<string> => {
   try {
     const response = await fetch(env.OPENCRVS_PUBLIC_KEY_URL);
     return response.text();
   } catch (error) {
-    console.error(
-      `🔑  Failed to fetch public key from Core. Make sure Core is running, and you are able to connect to ${env.OPENCRVS_PUBLIC_KEY_URL}`,
+    logger.warn(
+      {
+        event: "opencrvs.public-key.fetch.failed",
+        opencrvsPublicKeyUrl: env.OPENCRVS_PUBLIC_KEY_URL,
+        err: error,
+      },
+      "Failed to fetch OpenCRVS public key",
     );
+
     if (env.isProd) {
       throw error;
     }
+
     await new Promise((resolve) => setTimeout(resolve, 3000));
-    return getPublicKey();
+    return getPublicKey(logger);
   }
 };
 

--- a/packages/mosip-api/src/routes/oidp-user-info.ts
+++ b/packages/mosip-api/src/routes/oidp-user-info.ts
@@ -19,24 +19,41 @@ export const OIDPUserInfoHandler = async (
   const { clientId, redirectUri } = request.body;
   const code = request.query.code;
 
-  console.log("OIDPUserInfoHandler", {
+  request.log.info({
+    event: "esignet.userinfo.request.received",
     clientId,
-    redirectUri,
-    code,
+    redirectUri: redirectUri.split("?")[0],
+    hasCode: Boolean(code),
   });
 
   const tokenResponse = await fetchToken({
     code,
     clientId,
     redirectUri,
+    logger: request.log,
   });
 
   if (!tokenResponse.access_token) {
+    request.log.warn(
+      {
+        event: "esignet.token.request.missing-access-token",
+      },
+      "E-Signet token response did not include access token",
+    );
+
     throw new Error(
-      "Something went wrong with the OIDP token request. No access token was returned. Response from OIDP: " +
-        JSON.stringify(tokenResponse),
+      "Something went wrong with the OIDP token request. No access token was returned.",
     );
   }
 
-  return fetchUserInfo(tokenResponse.access_token);
+  const userInfo = await fetchUserInfo(tokenResponse.access_token, request.log);
+
+  request.log.info(
+    {
+      event: "esignet.userinfo.request.succeeded",
+    },
+    "Successfully fetched OIDP user info",
+  );
+
+  return userInfo;
 };

--- a/packages/mosip-api/src/routes/websub-credential-issued.ts
+++ b/packages/mosip-api/src/routes/websub-credential-issued.ts
@@ -94,7 +94,16 @@ export const credentialIssuedHandler = async (
       })
       .status(200);
   } catch (error) {
-    console.error("error: ", error);
+    request.log.error(
+      {
+        event: "websub.credential-issued.failed",
+        err: error,
+        topic: request.body.topic,
+        eventId: request.body.event.id,
+      },
+      "Failed to process WebSub credential-issued event",
+    );
+
     return reply
       .send({
         publisher: request.body.publisher,

--- a/packages/mosip-mock/src/index.ts
+++ b/packages/mosip-mock/src/index.ts
@@ -9,7 +9,7 @@ import { packetManagerAuthHandler } from "./routes/packet-manager-auth";
 import { createPrivateKey, createPublicKey } from "node:crypto";
 import { PUBLIC_KEY_URL } from "./verifiable-credentials/issue";
 
-const app = Fastify();
+const app = Fastify({ logger: true });
 
 app.register(formbody);
 
@@ -50,8 +50,8 @@ app.post("/registrationprocessor/v1/workflowmanager/workflowinstance", {
 
 async function run() {
   if (env.isProd) {
-    console.error(
-      "⚠️ You are running MOCK national ID server in production. All identifiers will be logged. ⚠️",
+    app.log.warn(
+      "You are running MOCK national ID server in production. Identifiers can be logged.",
     );
   }
 
@@ -61,12 +61,10 @@ async function run() {
     host: env.HOST,
   });
 
-  const emailStatus = EMAIL_ENABLED
-    ? "✅ Emails enabled"
-    : "❌ Emails disabled";
+  const emailStatus = EMAIL_ENABLED ? "Emails enabled" : "Emails disabled";
 
-  console.log(`MOSIP mock server running at http://${env.HOST}:${env.PORT}`);
-  console.log(emailStatus);
+  app.log.info(`MOSIP mock server running at http://${env.HOST}:${env.PORT}`);
+  app.log.info(emailStatus);
 }
 
 void run();

--- a/packages/mosip-mock/src/mailer.ts
+++ b/packages/mosip-mock/src/mailer.ts
@@ -1,9 +1,20 @@
 import * as nodemailer from "nodemailer";
 import { EMAIL_ENABLED, env } from "./constants";
+import type { FastifyBaseLogger } from "fastify";
 
-export const sendEmail = async (subject: string, text: string) => {
+export const sendEmail = async (
+  subject: string,
+  text: string,
+  logger?: FastifyBaseLogger,
+) => {
   if (!EMAIL_ENABLED) {
-    console.log(`Interrupted email sending`, { subject, text });
+    logger?.info(
+      {
+        event: "mailer.skipped",
+      },
+      "Skipping email send because SMTP is disabled",
+    );
+
     return;
   }
 

--- a/packages/mosip-mock/src/routes/packet-manager-create.ts
+++ b/packages/mosip-mock/src/routes/packet-manager-create.ts
@@ -61,6 +61,14 @@ const sendVerifiableCredential = async (
   return response.text();
 };
 
+const maskIdentifier = (value: string) => {
+  if (value.length <= 4) {
+    return "*".repeat(value.length);
+  }
+
+  return `${"*".repeat(value.length - 4)}${value.slice(-4)}`;
+};
+
 type CrvsNewRequest = {
   request: {
     process: "CRVS_NEW";
@@ -105,11 +113,21 @@ export const packetManagerCreateHandler: RouteHandlerMethod = async (
     const birthCertificateNumber =
       payload.request.fields.birthCertificateNumber;
 
-    console.log(
-      `${JSON.stringify({ id, birthCertificateNumber }, null, 4)}, ..."${VID}" created.`,
+    request.log.info(
+      {
+        event: "packet-manager.create.birth",
+        requestId: id,
+        birthCertificateNumber: maskIdentifier(birthCertificateNumber),
+        vidSuffix: VID.slice(-4),
+      },
+      "Created mock identity",
     );
 
-    await sendEmail(`NID created for request id ${id}`, `NID: ${VID}`);
+    await sendEmail(
+      `NID created for request id ${id}`,
+      `NID: ${VID}`,
+      request.log,
+    );
 
     sendVerifiableCredential(id, {
       birthCertificateNumber,
@@ -117,7 +135,14 @@ export const packetManagerCreateHandler: RouteHandlerMethod = async (
       id: `http://credential.idrepo/credentials/${id}`,
       vcVer: "VC-V1",
     }).catch((e) => {
-      console.error(e);
+      request.log.error(
+        {
+          event: "packet-manager.websub-callback.failed",
+          err: e,
+          requestId: id,
+        },
+        "Failed to send verifiable credential callback",
+      );
     });
   }
 
@@ -129,7 +154,14 @@ export const packetManagerCreateHandler: RouteHandlerMethod = async (
       id: `http://credential.idrepo/credentials/${id}`,
       vcVer: "VC-V1",
     }).catch((e) => {
-      console.error(e);
+      request.log.error(
+        {
+          event: "packet-manager.websub-callback.failed",
+          err: e,
+          requestId: id,
+        },
+        "Failed to send verifiable credential callback",
+      );
     });
 
     nationalIdNumber && deactivateNid(nationalIdNumber);


### PR DESCRIPTION
## Summary
- replace ad-hoc `console.*` usage in API and mocks with structured Fastify logger calls to make logging consistent across services
- remove sensitive token/assertion/userinfo logging from OIDP flows and add redaction for auth/token-like fields in `mosip-api` logger config
- keep logs debuggable with stable event names and contextual metadata while masking mock identifiers where appropriate

