### PR TITLE
harden mosip-api Docker runtime and align sqlite ownership

### DIFF
--- a/packages/esignet-mock/Dockerfile
+++ b/packages/esignet-mock/Dockerfile
@@ -1,9 +1,15 @@
-FROM node:23.1.0
+FROM node:23.9.0-bookworm-slim
+
+ENV NODE_ENV=production
 WORKDIR /usr/src/app
 
 COPY package.json package.json
 COPY yarn.lock yarn.lock
-RUN yarn install --production --frozen-lockfile
+RUN yarn install --production --frozen-lockfile && yarn cache clean
 COPY src/ src/
+
+RUN chown -R node:node /usr/src/app
+
+USER node
 
 CMD ["yarn", "start"]

--- a/packages/mosip-api/Dockerfile
+++ b/packages/mosip-api/Dockerfile
@@ -1,10 +1,16 @@
-FROM node:23.1.0
+FROM node:23.9.0-bookworm-slim
+
+ENV NODE_ENV=production
 WORKDIR /usr/src/app
 
 COPY package.json package.json
 COPY yarn.lock yarn.lock
 COPY tsconfig.json tsconfig.json
-RUN yarn install --production --frozen-lockfile
+RUN yarn install --production --frozen-lockfile && yarn cache clean
 COPY src/ src/
+
+RUN mkdir -p /data/sqlite && chown -R node:node /usr/src/app /data/sqlite
+
+USER node
 
 CMD ["yarn", "start"]

--- a/packages/mosip-api/Dockerfile
+++ b/packages/mosip-api/Dockerfile
@@ -9,7 +9,7 @@ COPY tsconfig.json tsconfig.json
 RUN yarn install --production --frozen-lockfile && yarn cache clean
 COPY src/ src/
 
-RUN mkdir -p /data/sqlite && chown -R node:node /usr/src/app /data/sqlite
+RUN chown -R node:node /usr/src/app
 
 USER node
 

--- a/packages/mosip-mock/Dockerfile
+++ b/packages/mosip-mock/Dockerfile
@@ -1,10 +1,16 @@
-FROM node:23.1.0
+FROM node:23.9.0-bookworm-slim
+
+ENV NODE_ENV=production
 WORKDIR /usr/src/app
 
 COPY package.json package.json
 COPY yarn.lock yarn.lock
 COPY tsconfig.json tsconfig.json
-RUN yarn install --production --frozen-lockfile
+RUN yarn install --production --frozen-lockfile && yarn cache clean
 COPY src/ src/
+
+RUN chown -R node:node /usr/src/app
+
+USER node
 
 CMD ["yarn", "start"]


### PR DESCRIPTION
## Summary
- harden the `mosip-api` runtime image by running as non-root and ensuring application files are owned by the `node` user
- remove image-level creation/chown of `/data/sqlite` and rely on deployment infrastructure to provision and mount that path
- align container behavior with Farajaland deployment where `/data/sqlite` is a host-mounted volume

## Why
- mounted host volumes override image filesystem paths, so ownership for `/data/sqlite` should be managed in infrastructure rather than in the Docker image
- keeping ownership setup focused on `/usr/src/app` makes runtime intent clearer and avoids redundant image steps

## Verification
- inspected deploy configuration to confirm `mosip-api` mounts `/data/sqlite` and uses `/data/sqlite/mosip-api.db`