### PR TITLE
feat: allow returning raw OIDP data for verificationStatus flexibility

### DIFF
--- a/packages/mosip-api/package.json
+++ b/packages/mosip-api/package.json
@@ -14,6 +14,7 @@
     "@fastify/jwt": "^9.0.4",
     "@fastify/swagger": "^9.5.1",
     "@fastify/swagger-ui": "^5.1.0",
+    "@opencrvs/mosip": "^2.0.0-rc.1",
     "@opencrvs/toolkit": "1.9.10-rc.9afdb31",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.8.2",

--- a/packages/mosip-api/src/esignet-api.ts
+++ b/packages/mosip-api/src/esignet-api.ts
@@ -164,7 +164,7 @@ function formatDate(dateString: string, formatStr = "PP") {
   });
 }
 
-const pickUserInfo = async (userInfo: OIDPUserInfo) => {
+export const pickUserInfo = async (userInfo: OIDPUserInfo) => {
   return {
     name: {
       firstname: userInfo.name?.split(" ")[0],
@@ -217,5 +217,5 @@ export const fetchUserInfo = async (
       "Something went wrong with the OIDP user info request. No user info was returned.",
     );
   }
-  return pickUserInfo(decodedResponse);
+  return decodedResponse;
 };

--- a/packages/mosip-api/src/index.ts
+++ b/packages/mosip-api/src/index.ts
@@ -12,7 +12,10 @@ import formbody from "@fastify/formbody";
 import cors from "@fastify/cors";
 import jwt from "@fastify/jwt";
 import { getPublicKey } from "./opencrvs-api";
-import { OIDPUserInfoHandler } from "./routes/oidp-user-info";
+import {
+  OIDPUserInfoHandler,
+  rawOIDPUserInfoHandler,
+} from "./routes/oidp-user-info";
 import { initSqlite } from "./database";
 import {
   credentialIssuedHandler,
@@ -121,6 +124,15 @@ const initRoutes = (app: FastifyInstance) => {
     url: "/esignet/get-oidp-user-info",
     method: "POST",
     handler: OIDPUserInfoHandler,
+    schema: {
+      body: OIDPUserInfoSchema,
+      querystring: OIDPQuerySchema,
+    },
+  });
+  app.withTypeProvider<ZodTypeProvider>().route({
+    url: "/esignet/get-oidp-user-info/raw",
+    method: "POST",
+    handler: rawOIDPUserInfoHandler,
     schema: {
       body: OIDPUserInfoSchema,
       querystring: OIDPQuerySchema,

--- a/packages/mosip-api/src/routes/oidp-user-info.ts
+++ b/packages/mosip-api/src/routes/oidp-user-info.ts
@@ -4,6 +4,7 @@ import {
   OIDPUserInfoSchema,
   fetchToken,
   fetchUserInfo,
+  pickUserInfo,
 } from "../esignet-api";
 import { z } from "zod";
 
@@ -12,7 +13,7 @@ export type OIDPUserInfoRequest = FastifyRequest<{
   Querystring: z.infer<typeof OIDPQuerySchema>;
 }>;
 
-export const OIDPUserInfoHandler = async (
+export const rawOIDPUserInfoHandler = async (
   request: OIDPUserInfoRequest,
   _reply: FastifyReply,
 ) => {
@@ -56,4 +57,12 @@ export const OIDPUserInfoHandler = async (
   );
 
   return userInfo;
+};
+
+export const OIDPUserInfoHandler = async (
+  request: OIDPUserInfoRequest,
+  _reply: FastifyReply,
+) => {
+  const userInfoRaw = await rawOIDPUserInfoHandler(request, _reply);
+  return pickUserInfo(userInfoRaw);
 };


### PR DESCRIPTION
The idea of this is that countries can call the OIDP endpoint directly from country config and decide the `verificationStatus` based on that.