### PR TITLE
feat: make PSUT deterministic based on NID for mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "license": "MPL-2.0",
   "private": true,
   "packageManager": "yarn@1.22.13",

--- a/packages/country-config/package.json
+++ b/packages/country-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "license": "MPL-2.0",
   "main": "./build/index.js",
   "exports": {

--- a/packages/esignet-mock/package.json
+++ b/packages/esignet-mock/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencrvs/esignet-mock",
   "license": "MPL-2.0",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "main": "index.js",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch src/index.ts",

--- a/packages/esignet-mock/src/index.ts
+++ b/packages/esignet-mock/src/index.ts
@@ -119,7 +119,7 @@ app.get("/oidc/userinfo", {
     }
 
     const userInfo: OIDPUserInfo = {
-      sub: "405710304278395",
+      sub: "1234567890" + "1234567890" + "123456" + nid, // mosip.kernel.tokenid.length (PSUT) is generally 36 characters
       name: `${identity.firstName} ${identity.familyName}`,
       given_name: identity.firstName,
       family_name: identity.familyName,

--- a/packages/mosip-api/package.json
+++ b/packages/mosip-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip-api",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "license": "MPL-2.0",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch --env-file-if-exists=../../.env src/index.ts",

--- a/packages/mosip-api/src/esignet-api.ts
+++ b/packages/mosip-api/src/esignet-api.ts
@@ -166,6 +166,7 @@ function formatDate(dateString: string, formatStr = "PP") {
 
 const pickUserInfo = async (userInfo: OIDPUserInfo) => {
   return {
+    sub: userInfo.sub, // usually holds the PSUT
     name: {
       firstname: userInfo.name?.split(" ")[0],
       surname: userInfo.name?.split(" ").at(-1),

--- a/packages/mosip-mock/package.json
+++ b/packages/mosip-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip-mock",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "license": "MPL-2.0",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch src/index.ts",


### PR DESCRIPTION
* `esignet-mock:` return a deterministic PSUT based on the NID of the person for mock
* `mosip-api`: return the PSUT (`sub` in JWT) to the country-config HTTP call. This will make it available in `event_actions` and therefore we can later use it.