### PR TITLE
remove esignet mock validating `state` as required

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "license": "MPL-2.0",
   "private": true,
   "packageManager": "yarn@1.22.13",

--- a/packages/country-config/package.json
+++ b/packages/country-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "license": "MPL-2.0",
   "main": "./build/index.js",
   "exports": {

--- a/packages/esignet-mock/package.json
+++ b/packages/esignet-mock/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencrvs/esignet-mock",
   "license": "MPL-2.0",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "main": "index.js",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch src/index.ts",

--- a/packages/esignet-mock/src/index.ts
+++ b/packages/esignet-mock/src/index.ts
@@ -185,20 +185,11 @@ app.get("/authorize", {
     const htmlFilePath = path.join(__dirname, "./mock-authorizer/index.html");
     const html = readFileSync(htmlFilePath, "utf-8");
 
-    const modifiedHtml = html
-      .replace(/{{client_id}}/g, request.query.client_id)
-      .replace(/{{response_type}}/g, request.query.response_type)
-      .replace(/{{scope}}/g, request.query.scope)
-      .replace(/{{acr_values}}/g, request.query.acr_values)
-      .replace(/{{claims}}/g, request.query.claims)
-      .replace(/{{state}}/g, request.query.state)
-      .replace(/{{redirect_uri}}/g, request.query.redirect_uri);
-
     /** See `packages/mosip-api/src/esignet-api.ts` for `redirect_uri: redirectUri?.split("?")[0] ?? redirectUri` to understand the matching of this */
     /** @see VALID_REDIRECT_URIS for explanation */
     VALID_REDIRECT_URIS.push(request.query.redirect_uri.split("?")[0]);
 
-    return reply.type("text/html").send(modifiedHtml);
+    return reply.type("text/html").send(html);
   },
 });
 

--- a/packages/esignet-mock/src/index.ts
+++ b/packages/esignet-mock/src/index.ts
@@ -164,7 +164,6 @@ const authorizeSchema = {
       "scope",
       "acr_values",
       "claims",
-      "state",
       "redirect_uri",
     ],
     properties: {

--- a/packages/esignet-mock/src/mock-authorizer/index.html
+++ b/packages/esignet-mock/src/mock-authorizer/index.html
@@ -180,7 +180,10 @@
         const personId = document.getElementById("id-input").value;
         // it's base64'd using `btoa` so that in demo the NID doesn't leak to URL and cause awkward questions
         destinationURL.searchParams.set("code", btoa(personId));
-        destinationURL.searchParams.set("state", params.get("state"));
+
+        if (params.get("state"))
+          destinationURL.searchParams.set("state", params.get("state"));
+
         console.log(destinationURL.href);
         window.location.replace(destinationURL.href);
       }

--- a/packages/esignet-mock/src/mock-authorizer/index.html
+++ b/packages/esignet-mock/src/mock-authorizer/index.html
@@ -79,18 +79,6 @@
     </style>
   </head>
   <body>
-    <!--
-    <p>client_id: {{client_id}}</p>
-    <p>response_type: {{response_type}}</p>
-    <p>scope: {{scope}}</p>
-    <p>acr_values: {{acr_values}}</p>
-    <p>claims: {{claims}}</p>
-    <p>state: {{state}}</p>
-    <p>redirect_uri: {{redirect_uri}}</p>
-    
-    -->
-    <!--<button onclick="handleClick()">Authorize person</button>-->
-
     <header>
       <img
         src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='320' height='320' viewBox='0 0 320 320'><defs><clipPath id='clip-Original_Small_Scale_Logo_SVG'><rect width='320' height='320'/></clipPath></defs><g id='Original_Small_Scale_Logo_SVG' clip-path='url(%23clip-Original_Small_Scale_Logo_SVG)'><path id='Path_54' data-name='Path 54' d='M135.739,0h-4.277A131.574,131.574,0,0,0,0,131.686v.2a123.842,123.842,0,0,0,123.943,123.74H251.934a15.51,15.51,0,0,0,15.489-15.5V131.686c0-.078,0-.155,0-.233A131.569,131.569,0,0,0,135.739,0m86.643,221.217-.011.038-.746,0-.037,0-.04,0-81.484-.2c-2.156.131-4.33.2-6.521.2-2.253,0-4.482-.1-6.7-.234H126.5l.011-.023c-51.621-3.392-92.384-43.748-92.384-93.067,0-51.542,44.512-93.326,99.419-93.326s99.42,41.783,99.42,93.326A88.046,88.046,0,0,1,230.386,149L126.5,148.993c-11.24,0-20.426-8.382-20.426-18.934s9.185-18.081,20.426-18.081h3.593l61.369.279c-7.242-23.623-30.422-40.91-57.917-40.91-33.29,0-60.278,25.333-60.278,56.583s26.988,56.583,60.278,56.583h87.263l.059.034c.242-.007.48-.034.723-.034,10.809,0,19.571,8.226,19.571,18.371,0,9.895-8.339,17.939-18.777,18.334' transform='translate(26 32)' fill='%23eb6f2d'/></g></svg>"

--- a/packages/mosip-api/package.json
+++ b/packages/mosip-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip-api",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "license": "MPL-2.0",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch --env-file-if-exists=../../.env src/index.ts",

--- a/packages/mosip-mock/package.json
+++ b/packages/mosip-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip-mock",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "license": "MPL-2.0",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch src/index.ts",


### PR DESCRIPTION
Per, https://docs.esignet.io/esignet-authentication/develop/integration/relying-party/development-and-integration-with-esignet `state` is optional.