### PR TITLE
allow updating biographics on MOSIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ touch .env
 yarn dev
 
 # only run the main server without mocks
-yarn dev --filter=@opencrvs/mosip-api
+yarn workspace @opencrvs/mosip-api run dev
 
 # bump package.json versions
 yarn set-version 1.7.0-alpha.16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip",
-  "version": "2.0.0-rc.5",
+  "version": "2.0.0-rc.6",
   "license": "MPL-2.0",
   "private": true,
   "packageManager": "yarn@1.22.13",

--- a/packages/country-config/package.json
+++ b/packages/country-config/package.json
@@ -15,7 +15,7 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@opencrvs/toolkit": "1.9.10-rc.9afdb31",
+    "@opencrvs/toolkit": "1.9.12-rc.1b9bbf4",
     "@types/hapi__hapi": "^20.0.0",
     "@types/node-fetch": "^2.6.11",
     "node-fetch": "2.6.7",

--- a/packages/country-config/package.json
+++ b/packages/country-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip",
-  "version": "2.0.0-rc.5",
+  "version": "2.0.0-rc.6",
   "license": "MPL-2.0",
   "main": "./build/index.js",
   "exports": {

--- a/packages/country-config/src/api.ts
+++ b/packages/country-config/src/api.ts
@@ -11,6 +11,16 @@ export const DeathRequestFieldsSchema = z.looseObject({
   birthCertificateNumber: z.undefined().optional(),
 });
 
+export const CorrectionRequestFieldsSchema = z.looseObject({
+  VID: z.string(),
+  fullName: z.string().optional(),
+  dateOfBirth: z.string().optional(),
+  gender: z.string().optional(),
+  introducerInfoToken: z.string().optional(),
+  birthCertificateNumber: z.undefined().optional(),
+  deathCertificateNumber: z.undefined().optional(),
+});
+
 export const MosipNotificationSchema = z.object({
   recipientFullName: z.string(),
   recipientEmail: z.string(),
@@ -20,7 +30,26 @@ export const MosipNotificationSchema = z.object({
 export const MosipInteropPayloadSchema = z.object({
   trackingId: z.string(),
   notification: MosipNotificationSchema,
-  requestFields: z.union([BirthRequestFieldsSchema, DeathRequestFieldsSchema]),
+  requestFields: z.union([
+    BirthRequestFieldsSchema,
+    DeathRequestFieldsSchema,
+    CorrectionRequestFieldsSchema,
+  ]),
+  schemaJson: z.string().optional(),
+  metaInfo: z.record(z.string(), z.unknown()),
+  audit: z.record(z.string(), z.unknown()),
+});
+
+export const MosipCorrectionPayloadSchema = z.object({
+  trackingId: z.string(),
+  notification: MosipNotificationSchema,
+  requestFields: z.object({
+    VID: z.string(),
+    fullName: z.string().optional(),
+    dateOfBirth: z.string().optional(),
+    gender: z.string().optional(),
+    introducerInfoToken: z.string().optional(),
+  }),
   schemaJson: z.string().optional(),
   metaInfo: z.record(z.string(), z.unknown()),
   audit: z.record(z.string(), z.unknown()),
@@ -48,7 +77,9 @@ export const RegistrationEventResponseSchema = z.record(
 
 export type BirthRequestFields = z.infer<typeof BirthRequestFieldsSchema>;
 export type DeathRequestFields = z.infer<typeof DeathRequestFieldsSchema>;
+export type CorrectionRequestFields = z.infer<typeof CorrectionRequestFieldsSchema>;
 export type MosipInteropPayload = z.infer<typeof MosipInteropPayloadSchema>;
+export type MosipCorrectionPayload = z.infer<typeof MosipCorrectionPayloadSchema>;
 export type VerifyNidPayload = z.infer<typeof VerifyNidPayloadSchema>;
 export type VerifyNidResponse = z.infer<typeof VerifyNidResponseSchema>;
 
@@ -105,6 +136,30 @@ export const createMosipInteropClient = (
 
       if (!response.ok) {
         throw new Error(`Failed to register event: ${await response.text()}`);
+      }
+
+      return RegistrationEventResponseSchema.parse(await response.json());
+    },
+    updateBiographics: async (payload: MosipCorrectionPayload) => {
+      const parsedPayload = MosipCorrectionPayloadSchema.parse(payload);
+      const MOSIP_API_CORRECTION_EVENT_URL = new URL(
+        "./events/update-biographics",
+        url,
+      ).href;
+
+      const response = await fetchWithTimeout(MOSIP_API_CORRECTION_EVENT_URL, {
+        method: "POST",
+        body: JSON.stringify(parsedPayload),
+        headers: {
+          Authorization: authorizationHeader,
+          "content-type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to update biographics: ${await response.text()}`,
+        );
       }
 
       return RegistrationEventResponseSchema.parse(await response.json());

--- a/packages/esignet-mock/package.json
+++ b/packages/esignet-mock/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencrvs/esignet-mock",
   "license": "MPL-2.0",
-  "version": "2.0.0-rc.5",
+  "version": "2.0.0-rc.6",
   "main": "index.js",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch src/index.ts",

--- a/packages/mosip-api/package.json
+++ b/packages/mosip-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip-api",
-  "version": "2.0.0-rc.5",
+  "version": "2.0.0-rc.6",
   "license": "MPL-2.0",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch --env-file-if-exists=../../.env src/index.ts",

--- a/packages/mosip-api/src/index.test.ts
+++ b/packages/mosip-api/src/index.test.ts
@@ -24,7 +24,9 @@ const createJwtPayload = () => ({
   sub: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
 });
 
-const createPacketRequests: Array<{ request: { schemaJson: string } }> = [];
+const createPacketRequests: Array<{
+  request: { schemaJson: string; process: string; fields: Record<string, unknown> };
+}> = [];
 
 const mswServer = setupServer(
   http.get(env.OPENCRVS_PUBLIC_KEY_URL, () => {
@@ -39,7 +41,13 @@ const mswServer = setupServer(
   }),
   http.put(env.MOSIP_CREATE_PACKET_URL, async ({ request }) => {
     createPacketRequests.push(
-      (await request.json()) as { request: { schemaJson: string } },
+      (await request.json()) as {
+        request: {
+          schemaJson: string;
+          process: string;
+          fields: Record<string, unknown>;
+        };
+      },
     );
     return HttpResponse.json({ response: { id: "ok" } });
   }),
@@ -154,6 +162,40 @@ test("validates JWTs", async (t) => {
       createPacketRequests[0]?.request?.schemaJson,
       customSchemaJson,
     );
+  });
+
+  await t.test("should accept correction updates and send CRVS_UPDATE process", async () => {
+    createPacketRequests.length = 0;
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/events/update-biographics",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${createValidJwt()}`,
+      },
+      body: JSON.stringify({
+        trackingId: "tracking-id-correction",
+        notification: {
+          recipientFullName: "Jane Doe",
+          recipientEmail: "jane@example.com",
+          recipientPhone: "+1555000114",
+        },
+        requestFields: {
+          VID: "8031687218",
+          fullName: "Infant Updated",
+          dateOfBirth: "2024-01-01",
+          gender: "male",
+        },
+        metaInfo: {},
+        audit: {},
+      }),
+    });
+
+    assert.strictEqual(response.statusCode, 202);
+    assert.strictEqual(createPacketRequests.length, 1);
+    assert.strictEqual(createPacketRequests[0]?.request?.process, "CRVS_UPDATE");
+    assert.strictEqual(createPacketRequests[0]?.request?.fields?.VID, "8031687218");
   });
 
   await fastify.close();

--- a/packages/mosip-api/src/index.ts
+++ b/packages/mosip-api/src/index.ts
@@ -5,6 +5,7 @@ import {
   ZodTypeProvider,
 } from "fastify-type-provider-zod";
 import { registrationEventHandler } from "./routes/event-registration";
+import { updateBiographicsHandler } from "./routes/update-biographics";
 import { env } from "./constants";
 import * as openapi from "./openapi-documentation";
 import { OIDPUserInfoSchema, OIDPQuerySchema } from "./esignet-api";
@@ -104,6 +105,11 @@ const initRoutes = (app: FastifyInstance) => {
     schema: {
       body: MosipInteropPayloadSchema,
     },
+  });
+  app.withTypeProvider<ZodTypeProvider>().route({
+    url: "/events/update-biographics",
+    method: "POST",
+    handler: updateBiographicsHandler,
   });
   app.withTypeProvider<ZodTypeProvider>().route({
     url: "/verify",

--- a/packages/mosip-api/src/mosip-api.ts
+++ b/packages/mosip-api/src/mosip-api.ts
@@ -3,6 +3,7 @@ import MOSIPAuthenticator from "@mosip/ida-auth-sdk";
 import { schemaJson as defaultSchemaJson } from "./types/idSchemaJson";
 import {
   BirthRequestFields,
+  CorrectionRequestFields,
   DeathRequestFields,
   MosipInteropPayload,
 } from "@opencrvs/mosip/api";
@@ -248,6 +249,110 @@ export const postDeathRecord = async ({
       request: {
         registrationId: event.id,
         process: "CRVS_DEATH",
+        source: "CRVS1",
+        additionalInfoReqId: "",
+        notificationInfo: {
+          name: notification.recipientFullName,
+          phone: notification.recipientPhone || "",
+          email: notification.recipientEmail || "",
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+  const processPacketResponse = await fetch(env.MOSIP_PROCESS_PACKET_URL, {
+    method: "POST",
+    body: processPacketRequestBody,
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: `Authorization=${authToken};`,
+    },
+  });
+
+  if (!processPacketResponse.ok) {
+    throw new Error(
+      `Failed sending record to MOSIP, response: ${await processPacketResponse.text()}`,
+    );
+  }
+
+  const processPacketResponseJson = await processPacketResponse.json();
+
+  if (processPacketResponseJson?.errors?.length > 0) {
+    throw new Error(
+      `Error in processing packet, response: ${await processPacketResponseJson?.errors[0]?.message}`,
+    );
+  }
+};
+
+export const postDemographicUpdateRecord = async ({
+  event,
+  requestFields,
+  schemaJson,
+  audit,
+  metaInfo,
+  notification,
+}: {
+  event: {
+    id: string;
+    trackingId: string;
+  };
+  requestFields: CorrectionRequestFields;
+  schemaJson?: string;
+  audit: MosipInteropPayload["audit"];
+  metaInfo: MosipInteropPayload["metaInfo"];
+  notification: MosipInteropPayload["notification"];
+}) => {
+  const authToken = await getMosipAuthToken("PACKET");
+
+  const updatePacketRequestBody = JSON.stringify(
+    {
+      id: "string",
+      version: "string",
+      requesttime: new Date().toISOString(),
+      request: {
+        id: event.id,
+        refId: `${env.MOSIP_CENTER_ID}_${env.MOSIP_MACHINE_ID}`,
+        offlineMode: false,
+        process: "CRVS_UPDATE",
+        source: "CRVS1",
+        schemaVersion: "0.500",
+        fields: requestFields,
+        metaInfo: metaInfo,
+        audits: Array.of(audit),
+        schemaJson: schemaJson ?? defaultSchemaJson,
+      },
+    },
+    null,
+    2,
+  );
+
+  const updatePacketResponse = await fetch(env.MOSIP_CREATE_PACKET_URL, {
+    method: "PUT",
+    body: updatePacketRequestBody,
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: `Authorization=${authToken};`,
+    },
+  });
+
+  if (!updatePacketResponse.ok) {
+    throw new Error(
+      `Failed sending record to MOSIP, response: ${await updatePacketResponse.text()}`,
+    );
+  }
+
+  await updatePacketResponse.json();
+
+  const processPacketRequestBody = JSON.stringify(
+    {
+      id: "mosip.registration.processor.workflow.instance",
+      requesttime: new Date().toISOString(),
+      version: "v1",
+      request: {
+        registrationId: event.id,
+        process: "CRVS_UPDATE",
         source: "CRVS1",
         additionalInfoReqId: "",
         notificationInfo: {

--- a/packages/mosip-api/src/routes/update-biographics.ts
+++ b/packages/mosip-api/src/routes/update-biographics.ts
@@ -1,0 +1,52 @@
+import { FastifyRequest, FastifyReply } from "fastify";
+import * as mosip from "../mosip-api";
+import crypto from "node:crypto";
+import { z } from "zod";
+
+const MosipCorrectionPayloadSchema = z.object({
+  trackingId: z.string(),
+  notification: z.object({
+    recipientFullName: z.string(),
+    recipientEmail: z.string(),
+    recipientPhone: z.string(),
+  }),
+  requestFields: z.object({
+    VID: z.string(),
+    fullName: z.string().optional(),
+    dateOfBirth: z.string().optional(),
+    gender: z.string().optional(),
+    introducerInfoToken: z.string().optional(),
+  }),
+  schemaJson: z.string().optional(),
+  metaInfo: z.record(z.string(), z.unknown()),
+  audit: z.record(z.string(), z.unknown()),
+});
+
+export const updateBiographicsHandler = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const body = MosipCorrectionPayloadSchema.parse(request.body);
+
+  const {
+    trackingId,
+    requestFields,
+    schemaJson,
+    audit,
+    metaInfo,
+    notification,
+  } = body;
+
+  request.log.info({ trackingId }, "Received correction update from OpenCRVS");
+
+  await mosip.postDemographicUpdateRecord({
+    event: { id: crypto.randomUUID(), trackingId },
+    requestFields,
+    schemaJson,
+    audit,
+    metaInfo,
+    notification,
+  });
+
+  return reply.code(202).send({});
+};

--- a/packages/mosip-mock/package.json
+++ b/packages/mosip-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/mosip-mock",
-  "version": "2.0.0-rc.5",
+  "version": "2.0.0-rc.6",
   "license": "MPL-2.0",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch src/index.ts",

--- a/packages/mosip-mock/src/routes/packet-manager-create.ts
+++ b/packages/mosip-mock/src/routes/packet-manager-create.ts
@@ -89,7 +89,21 @@ type CrvsDeathRequest = {
   };
 };
 
-type CrvsRequest = CrvsNewRequest | CrvsDeathRequest;
+type CrvsUpdateRequest = {
+  request: {
+    process: "CRVS_UPDATE";
+    id: string;
+    fields: {
+      VID: string;
+      fullName?: string;
+      dateOfBirth?: string;
+      gender?: string;
+      introducerInfoToken?: string;
+    };
+  };
+};
+
+type CrvsRequest = CrvsNewRequest | CrvsDeathRequest | CrvsUpdateRequest;
 
 const isCrvsNewRequest = (request: CrvsRequest): request is CrvsNewRequest => {
   return request.request.process === "CRVS_NEW";
@@ -99,6 +113,12 @@ const isCrvsDeathRequest = (
   request: CrvsRequest,
 ): request is CrvsDeathRequest => {
   return request.request.process === "CRVS_DEATH";
+};
+
+const isCrvsUpdateRequest = (
+  request: CrvsRequest,
+): request is CrvsUpdateRequest => {
+  return request.request.process === "CRVS_UPDATE";
 };
 
 export const packetManagerCreateHandler: RouteHandlerMethod = async (
@@ -167,6 +187,38 @@ export const packetManagerCreateHandler: RouteHandlerMethod = async (
     nationalIdNumber && deactivateNid(nationalIdNumber);
   }
 
+  if (isCrvsUpdateRequest(payload)) {
+    const id = payload.request.id;
+    const { VID, fullName, dateOfBirth, gender, introducerInfoToken } =
+      payload.request.fields;
+
+    await sendEmail(
+      `Biographic update received for VID ${VID}`,
+      [
+        `Request ID: ${id}`,
+        `VID: ${VID}`,
+        `Name updated: ${Boolean(fullName)}`,
+        `DOB updated: ${Boolean(dateOfBirth)}`,
+        `Gender updated: ${Boolean(gender)}`,
+        `Introducer token present: ${Boolean(introducerInfoToken)}`,
+      ].join("\n"),
+      request.log,
+    );
+
+    request.log.info(
+      {
+        event: "packet-manager.update-biographics",
+        requestId: id,
+        vidSuffix: VID.slice(-4),
+        hasFullName: Boolean(fullName),
+        hasDateOfBirth: Boolean(dateOfBirth),
+        hasGender: Boolean(gender),
+        hasIntroducerInfoToken: Boolean(introducerInfoToken),
+      },
+      "Received mock demographic update request",
+    );
+  }
+
   return reply.status(200).send({
     id: "mosip.registration.packet.writer",
     version: "v1",
@@ -177,7 +229,7 @@ export const packetManagerCreateHandler: RouteHandlerMethod = async (
         id: payload.request.id,
         packetName: "111111112_evidence",
         source: "CRVS1",
-        process: "CRVS_NEW",
+        process: payload.request.process,
         refId: payload.request.id,
         schemaVersion: "0.5",
         signature:
@@ -191,7 +243,7 @@ export const packetManagerCreateHandler: RouteHandlerMethod = async (
         id: payload.request.id,
         packetName: "111111112_optional",
         source: "CRVS1",
-        process: "CRVS_NEW",
+        process: payload.request.process,
         refId: payload.request.id,
         schemaVersion: "0.5",
         signature:
@@ -205,7 +257,7 @@ export const packetManagerCreateHandler: RouteHandlerMethod = async (
         id: payload.request.id,
         packetName: "111111112_id",
         source: "CRVS1",
-        process: "CRVS_NEW",
+        process: payload.request.process,
         refId: payload.request.id,
         schemaVersion: "0.1",
         signature:

--- a/yarn.lock
+++ b/yarn.lock
@@ -592,6 +592,26 @@
     zod "^4.1.12"
     zod-openapi "^5.4.3"
 
+"@opencrvs/toolkit@1.9.12-rc.1b9bbf4":
+  version "1.9.12-rc.1b9bbf4"
+  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.9.12-rc.1b9bbf4.tgz#63e4d87c96fede53ad7015b7948fb209b98f3bea"
+  integrity sha512-nRlyu9f5bL/4ZNHBNiSpZ8m9iO5g+H0VuMjrPm3MI8Ck3Aq7+ylXyxmukuhvOXfy7pCx5mxfOF9d1G/iTAD5OQ==
+  dependencies:
+    "@trpc/client" "11.4.3"
+    "@trpc/server" "^11.8.0"
+    ajv "^8.17.1"
+    ajv-formats "^3.0.1"
+    date-fns "^2.28.0"
+    jwt-decode "^3.0.0"
+    lodash "^4.17.10"
+    object-hash "^3.0.0"
+    qs "6.14.0"
+    superjson "1.9.0-0"
+    ts-morph "^27.0.2"
+    uuid "^9.0.0"
+    zod "^4.2.1"
+    zod-openapi "^5.4.6"
+
 "@pinojs/redact@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@pinojs/redact/-/redact-0.4.0.tgz#c3de060dd12640dcc838516aa2a6803cc7b2e9d6"
@@ -623,6 +643,20 @@
   version "11.4.3"
   resolved "https://registry.yarnpkg.com/@trpc/server/-/server-11.4.3.tgz#669a964c85a0feab45da51e3ad03f63668dba525"
   integrity sha512-wnWq3wiLlMOlYkaIZz+qbuYA5udPTLS4GVVRyFkr6aT83xpdCHyVtURT+u4hSoIrOXQM9OPCNXSXsAujWZDdaw==
+
+"@trpc/server@^11.8.0":
+  version "11.16.0"
+  resolved "https://registry.yarnpkg.com/@trpc/server/-/server-11.16.0.tgz#14977e2fc91367e5353af913105a3d866c41db98"
+  integrity sha512-XgGuUMddrUTd04+za/WE5GFuZ1/YU9XQG0t3VL5WOIu2JspkOlq6k4RYEiqS6HSJt+S0RXaPdIoE2anIP/BBRQ==
+
+"@ts-morph/common@~0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.28.1.tgz#10ec52182d5c310832b669af7784a34fc3da3ca1"
+  integrity sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==
+  dependencies:
+    minimatch "^10.0.1"
+    path-browserify "^1.0.1"
+    tinyglobby "^0.2.14"
 
 "@turbo/darwin-64@2.8.20":
   version "2.8.20"
@@ -1076,6 +1110,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -1124,6 +1163,13 @@ brace-expansion@^2.0.1:
   integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
   dependencies:
     balanced-match "^1.0.0"
+
+brace-expansion@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
+  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+  dependencies:
+    balanced-match "^4.0.2"
 
 braces@^3.0.3:
   version "3.0.3"
@@ -1205,6 +1251,11 @@ cliui@^8.0.1:
     string-width "^4.2.0"
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
+
+code-block-writer@^13.0.3:
+  version "13.0.3"
+  resolved "https://registry.yarnpkg.com/code-block-writer/-/code-block-writer-13.0.3.tgz#90f8a84763a5012da7af61319dd638655ae90b5b"
+  integrity sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -1767,6 +1818,11 @@ fastseries@^1.7.0:
   dependencies:
     reusify "^1.0.0"
     xtend "^4.0.0"
+
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -2366,6 +2422,13 @@ minimatch@^10.0.0:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^10.0.1:
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
+  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
+  dependencies:
+    brace-expansion "^5.0.5"
+
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -2557,6 +2620,11 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -2599,6 +2667,11 @@ picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pino-abstract-transport@^2.0.0:
   version "2.0.0"
@@ -3109,6 +3182,14 @@ thread-stream@^4.0.0:
   dependencies:
     real-require "^0.2.0"
 
+tinyglobby@^0.2.14:
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"
+  integrity sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
@@ -3145,6 +3226,14 @@ ts-api-utils@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.0.0.tgz#b9d7d5f7ec9f736f4d0f09758b8607979044a900"
   integrity sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==
+
+ts-morph@^27.0.2:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-27.0.2.tgz#7b2fcce6822eeca3942fa6c601f159d5920b1422"
+  integrity sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==
+  dependencies:
+    "@ts-morph/common" "~0.28.1"
+    code-block-writer "^13.0.3"
 
 tslib@2.6.2:
   version "2.6.2"
@@ -3372,12 +3461,12 @@ yoctocolors-cjs@^2.1.2:
   resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz#f4b905a840a37506813a7acaa28febe97767a242"
   integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
 
-zod-openapi@^5.4.3:
+zod-openapi@^5.4.3, zod-openapi@^5.4.6:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/zod-openapi/-/zod-openapi-5.4.6.tgz#000bedda0843c2ff1af3d7236e8d52d831115de4"
   integrity sha512-P2jsOOBAq/6hCwUsMCjUATZ8szkMsV5VAwZENfyxp2Hc/XPJQpVwAgevWZc65xZauCwWB9LAn7zYeiCJFAEL+A==
 
-zod@^4.1.12:
+zod@^4.1.12, zod@^4.2.1:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==


### PR DESCRIPTION
## Summary
- Adds support for updating biographics in MOSIP from OpenCRVS via a new `update-biographics` route.
- Implements the MOSIP update integration flow in `mosip-api`, including payload handling and service wiring, with corresponding test coverage updates.
- Updates standalone run instructions/dependencies and adjusts mock packet-manager behavior to support the new flow.

## Changes
- Added `packages/mosip-api/src/routes/update-biographics.ts` endpoint implementation.
- Extended `packages/mosip-api/src/mosip-api.ts` and `packages/mosip-api/src/index.ts` for update-biographics integration.
- Updated `packages/mosip-api/src/index.test.ts` and mock route behavior in `packages/mosip-mock/src/routes/packet-manager-create.ts`.
- Updated related country-config API wiring (`packages/country-config/src/api.ts`) and dependency metadata.

## Why
This enables MOSIP-linked records to keep biographic details synchronized when user details are corrected or updated in OpenCRVS.