### PR TITLE
allow configuring which field of the VC is used to populate national id

### DIFF
--- a/packages/mosip-api/src/constants.ts
+++ b/packages/mosip-api/src/constants.ts
@@ -55,6 +55,10 @@ export const env = cleanEnv(process.env, {
     example: "https://your-domain.com/.well-known/public-key.json",
     desc: "Comma-separated list of verifiable credential allowlist URLs. Used to verify the authenticity of the verifiable credential.",
   }),
+  MOSIP_VERIFIABLE_CREDENTIAL_NATIONAL_ID_KEY: str({
+    default: "UIN",
+    desc: "The key used to fill NATIONAL_ID field in OpenCRVS",
+  }),
   MOSIP_WEBSUB_AUTH_CLIENT_ID: str({ devDefault: "mosip-websub-client" }),
   MOSIP_WEBSUB_AUTH_CLIENT_SECRET: str({ devDefault: "abcdeABCDE123456" }),
 

--- a/packages/mosip-api/src/routes/websub-credential-issued.ts
+++ b/packages/mosip-api/src/routes/websub-credential-issued.ts
@@ -5,7 +5,7 @@ import { decode } from "jsonwebtoken";
 import * as opencrvs from "../opencrvs-api";
 import { decryptMosipCredential } from "../websub/crypto";
 import { env } from "../constants";
-import type { BirthSubject } from "../websub/verify-vc";
+import { getBirthIdentifier } from "../websub/verify-vc";
 import { ActionType } from "@opencrvs/toolkit/events";
 
 export const CredentialIssuedSchema = z.object({
@@ -23,7 +23,7 @@ export const CredentialIssuedSchema = z.object({
     data: z.object({
       registrationId: z.string(),
       credential: z.string(),
-      credentialType: z.literal("vercred"),
+      credentialType: z.literal("vercred").or(z.literal("euin")),
       protectionKey: z.string(),
     }),
   }),
@@ -68,8 +68,9 @@ export const credentialIssuedHandler = async (
           eventId,
           actionId,
           registrationNumber,
-          nationalId: (verifiableCredential.credentialSubject as BirthSubject)
-            .VID,
+          nationalId: getBirthIdentifier(
+            verifiableCredential.credentialSubject,
+          ),
         },
         { token, logger: request.log },
       );
@@ -92,8 +93,9 @@ export const credentialIssuedHandler = async (
           eventId,
           actionId,
           requestId: requestId!,
-          nationalId: (verifiableCredential.credentialSubject as BirthSubject)
-            .VID,
+          nationalId: getBirthIdentifier(
+            verifiableCredential.credentialSubject,
+          ),
         },
         { token, logger: request.log },
       );

--- a/packages/mosip-api/src/websub/verify-vc.test.ts
+++ b/packages/mosip-api/src/websub/verify-vc.test.ts
@@ -28,7 +28,7 @@ const VALID_CREDENTIAL = {
   issuanceDate: "2025-04-11T07:57:43.134Z",
   credentialSubject: {
     birthCertificateNumber: "C83B023548BST",
-    VID: "8031687218",
+    UIN: "8031687218",
     id: "http://credential.idrepo/credentials/100010033575073",
     vcVer: "VC-V1",
   },
@@ -39,7 +39,7 @@ const VALID_CREDENTIAL = {
     proofPurpose: "assertionMethod",
     verificationMethod:
       "https://legitimate.mosip.dev/.well-known/public-key.json",
-    jws: "eyJhbGciOiJQUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sImtpZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MjAyNDAvLndlbGwta25vd24vcHVibGljLWtleS5qc29uIn0..ZLUWGWVP3FrwTgVbcmaM2nb_ZcW4nWTcTflf1Zh-fieudW1BpqdH2LIpzzqvOeG1M4evJZEuJH2tlf4YxxUbN06r9ckz1PyaIjauCGlrwl1YCELUlbYoaCbLjHvZ96VgSFGzkRI6f3QiAYRi_SfgoEuAdRpve1xeIUFcFhCdxV94FTHovzoSWhOgd2KO3tQC_Ae2n2iv9cF07kCguqsCtDfsoGs775USW3JQE9rFYxg02w04qXn1RbMBLjpm6JZrG-jt-_h--HvNykUVO0wnmCMWtB4Rds3yD5EGe2CWwQ94RJBON3v5phMW_G0yAQ_TMB3Ogv7DpRv-VxhfY0FpkA",
+    jws: "eyJhbGciOiJQUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sImtpZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MjAyNDAvLndlbGwta25vd24vcHVibGljLWtleS5qc29uIn0..mSTm4pf8LIaxRIbocn1H8TCGT1inS543JMfvcwbnAq6TGKKRne8efwgenmh5BxqD_U7yx-zhu6tJxZ01EdEcSjfvD0DRPiySV_h2bhzk8lzhI-_LPgP3fl8DUFMqiTMcMk_eSPenLTiWAJxfMfrtTbidMIUa7o2yCEGParwHTZnGAdl4ydDvebqPEpsOuLVOh4x0MItXYxZr7_aXEd7ZIPF1-2nERXhEx9eCPD8rJsrj9r5Fz2H20ktvabiYfNcucbTmWU63nVx_b5viEf47WcGFH060_JJgoxlES2BicEUkf63F_w8OQv8iCHElY0VXDPYmk4s6MUQReDX-KgijWg",
   },
   type: ["VerifiableCredential", "MOSIPVerifiableCredential"],
   "@context": [

--- a/packages/mosip-api/src/websub/verify-vc.ts
+++ b/packages/mosip-api/src/websub/verify-vc.ts
@@ -1,13 +1,22 @@
 import { flattenedVerify, importSPKI } from "jose";
 import { z } from "zod";
 import canonicalize from "canonicalize";
+import { env } from "../constants";
 
-const BirthSubject = z.object({
-  birthCertificateNumber: z.string(),
-  VID: z.string(),
+const BirthSubject = z.looseObject({
   id: z.string().url(),
-  vcVer: z.literal("VC-V1"),
+  [env.MOSIP_VERIFIABLE_CREDENTIAL_NATIONAL_ID_KEY]: z.string(),
 });
+
+export const getBirthIdentifier = (credentialSubject: BirthSubject) => {
+  if (env.MOSIP_VERIFIABLE_CREDENTIAL_NATIONAL_ID_KEY in credentialSubject) {
+    return credentialSubject[env.MOSIP_VERIFIABLE_CREDENTIAL_NATIONAL_ID_KEY];
+  } else {
+    throw new Error(
+      `Invalid birth credential subject. Available keys: ${Object.keys(credentialSubject).join(", ")}`,
+    );
+  }
+};
 
 export type BirthSubject = z.infer<typeof BirthSubject>;
 
@@ -44,7 +53,7 @@ export const MOSIPVerifiableCredential = z.object({
 export const isBirthSubject = (
   subject: z.infer<typeof BirthSubject> | z.infer<typeof DeathSubject>,
 ): subject is z.infer<typeof BirthSubject> => {
-  return "birthCertificateNumber" in subject && "VID" in subject;
+  return env.MOSIP_VERIFIABLE_CREDENTIAL_NATIONAL_ID_KEY in subject;
 };
 
 export const verifyCredentialOrThrow = async (

--- a/packages/mosip-mock/src/routes/packet-manager-create.ts
+++ b/packages/mosip-mock/src/routes/packet-manager-create.ts
@@ -36,7 +36,7 @@ const sendVerifiableCredential = async (
           JSON.stringify(verifiableCredential),
           PRIVATE_KEY,
         ),
-        credentialType: "vercred",
+        credentialType: "euin",
         protectionKey: "275700",
       },
     },
@@ -59,14 +59,6 @@ const sendVerifiableCredential = async (
   }
 
   return response.text();
-};
-
-const maskIdentifier = (value: string) => {
-  if (value.length <= 4) {
-    return "*".repeat(value.length);
-  }
-
-  return `${"*".repeat(value.length - 4)}${value.slice(-4)}`;
 };
 
 type CrvsNewRequest = {
@@ -129,7 +121,7 @@ export const packetManagerCreateHandler: RouteHandlerMethod = async (
 
   if (isCrvsNewRequest(payload)) {
     const id = payload.request.id;
-    const VID = await createNid();
+    const UIN = await createNid();
     const birthCertificateNumber =
       payload.request.fields.birthCertificateNumber;
 
@@ -137,21 +129,21 @@ export const packetManagerCreateHandler: RouteHandlerMethod = async (
       {
         event: "packet-manager.create.birth",
         requestId: id,
-        birthCertificateNumber: maskIdentifier(birthCertificateNumber),
-        vidSuffix: VID.slice(-4),
+        birthCertificateNumber,
+        uin: UIN,
       },
       "Created mock identity",
     );
 
     await sendEmail(
       `NID created for request id ${id}`,
-      `NID: ${VID}`,
+      `NID: ${UIN}`,
       request.log,
     );
 
     sendVerifiableCredential(id, {
       birthCertificateNumber,
-      VID,
+      UIN,
       id: `http://credential.idrepo/credentials/${id}`,
       vcVer: "VC-V1",
     }).catch((e) => {


### PR DESCRIPTION
Collab and country implementations tend to use different identifier, NID / UIN / VID in the verifiable credentials. I used Collab's value for default `UIN`, but countries can now configure this without forking.