### PR TITLE
ignore the WebSub VC if action has already been accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Enabled `child.nid` creation support during birth correction flows.
   - To support this, the integration needs to fetch the record to know which action to confirm. Note that this adds a new record audit log row for `ActionType.VIEW`.
 
+- Handles synchronous action acceptance flows gracefully. Previously, the flow used async/202 country config action confirmation flows, but now all flows are supported.
+
 ## 1.9.0
 
 Before version 1.9, communication between country-config and mosip-api was handled via FHIR and GraphQL. OpenCRVS 1.9 introduces a refactored data model, new REST APIs, and new country configuration hooks such as onRegisterHandler. These changes require updates to country configurations, as the @opencrvs/mosip package has been updated accordingly. For detailed upgrade instructions, refer to [documentation.opencrvs.org](https://documentation.opencrvs.org).

--- a/packages/mosip-api/src/opencrvs-api.ts
+++ b/packages/mosip-api/src/opencrvs-api.ts
@@ -89,7 +89,7 @@ export const confirmRegistration = (
     });
 };
 
-export const getEventActionType = async (
+export const findEventActionType = async (
   eventId: string,
   { token }: { token: string },
 ) => {
@@ -97,7 +97,13 @@ export const getEventActionType = async (
   const client = createClient(url, `Bearer ${token}`);
 
   const event = (await client.event.get.query({ eventId })) as EventDocument;
-  const action = getPendingAction(event.actions);
+
+  let action: ReturnType<typeof getPendingAction>;
+  try {
+    action = getPendingAction(event.actions);
+  } catch {
+    return null;
+  }
 
   return {
     actionType: action.type,

--- a/packages/mosip-api/src/routes/websub-credential-issued.ts
+++ b/packages/mosip-api/src/routes/websub-credential-issued.ts
@@ -59,8 +59,33 @@ export const credentialIssuedHandler = async (
     const { token, registrationNumber } =
       getTransactionAndDiscard(transactionId);
     const { eventId, actionId } = decode(token) as TokenPayload;
-    const { actionType, eventType, requestId } =
-      await opencrvs.getEventActionType(eventId, { token });
+    const actionInfo = await opencrvs.findEventActionType(eventId, { token });
+
+    if (!actionInfo) {
+      request.log.info(
+        {
+          event: "websub.credential-issued.no-pending-action",
+          eventId,
+        },
+        "No pending action for event, skipping credential processing",
+      );
+      return reply
+        .send({
+          publisher: request.body.publisher,
+          topic: request.body.topic,
+          publishedOn: new Date().toISOString(),
+          event: {
+            id: request.body.event.id,
+            requestId: request.body.event.transactionId,
+            timestamp: new Date().toISOString(),
+            status: "RECEIVED",
+            url: "",
+          },
+        })
+        .status(200);
+    }
+
+    const { actionType, eventType, requestId } = actionInfo;
 
     if (actionType === ActionType.REGISTER && eventType === "birth") {
       await opencrvs.confirmRegistration(


### PR DESCRIPTION
Country config may have already accepted the action, with `.accept` or returning `200` instead of `202` to Core. This is a valid scenario how a country might configure their integration and we can just ignore the WebSub Verifiable Credential notification in that case.